### PR TITLE
44 add create project button to projects tab y paginado en toda la pagina

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import './App.css'
 import { SideMenu } from './components/app/side-menu'
 import { persistUser, readStoredUser } from './lib/auth-storage'
 import { AuthPage } from './pages/auth-page'
+import { GithubAuthCallbackPage } from './pages/github-auth-callback-page'
 import { LandingPage } from './pages/landing-page'
 import { ProjectDetailPage } from './pages/project-detail-page'
 import { TaskDetailPage } from './pages/task-detail-page'
@@ -57,6 +58,10 @@ function App() {
         <Route
           path="/auth/signup"
           element={<AuthPage mode="signup" onAuthSuccess={handleAuthSuccess} />}
+        />
+        <Route
+          path="/auth/github/callback"
+          element={<GithubAuthCallbackPage onAuthSuccess={handleAuthSuccess} />}
         />
         <Route
           path="/profile"

--- a/src/components/app/import-github-repos-modal.tsx
+++ b/src/components/app/import-github-repos-modal.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from 'react'
+import { ExternalLink, Github, LoaderCircle, Lock } from 'lucide-react'
+
+import { fetchGithubRepositories } from '../../lib/github-storage'
+import { createProject } from '../../lib/project-storage'
+import type { GithubRepository } from '../../types/app'
+import { Badge } from '../ui/badge'
+import { Button } from '../ui/button'
+import { Card, CardBody, CardDescription, CardTitle } from '../ui/card'
+import Modal from '../ui/modal'
+
+export function ImportGithubReposModal({
+  isOpen,
+  onClose,
+  onImported,
+}: {
+  isOpen: boolean
+  onClose: () => void
+  onImported?: () => void | Promise<void>
+}) {
+  const [repositories, setRepositories] = useState<GithubRepository[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [importingRepoId, setImportingRepoId] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    const loadRepositories = async () => {
+      setIsLoading(true)
+      setLoadError(null)
+
+      try {
+        const response = await fetchGithubRepositories()
+        if (response.status === 'success' && response.data) {
+          setRepositories(response.data)
+        } else {
+          setRepositories([])
+          setLoadError(response.message || 'Unable to load GitHub repositories.')
+        }
+      } catch (error) {
+        setRepositories([])
+        setLoadError(error instanceof Error ? error.message : 'Unable to load GitHub repositories.')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    loadRepositories().catch((error) => {
+      console.error(error)
+      setRepositories([])
+      setLoadError('Unable to load GitHub repositories.')
+      setIsLoading(false)
+    })
+  }, [isOpen])
+
+  async function handleImport(repository: GithubRepository) {
+    try {
+      setImportingRepoId(repository.id)
+      const response = await createProject({
+        ownerId: 0,
+        name: repository.name,
+        description: repository.description?.trim() || `${repository.fullName} imported from GitHub.`,
+        githubRepo: repository.htmlUrl,
+        status: 'OPEN',
+        tags: [],
+      })
+
+      if (response.status === 'error' || !response.data) {
+        setLoadError(response.message || 'Unable to import GitHub repository.')
+        return
+      }
+
+      await onImported?.()
+      onClose()
+    } catch (error) {
+      setLoadError(error instanceof Error ? error.message : 'Unable to import GitHub repository.')
+    } finally {
+      setImportingRepoId(null)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Import from GitHub">
+      <div className="space-y-4">
+        <Card className="border-slate-200 bg-slate-50/80 shadow-none">
+          <CardBody className="flex flex-row items-center gap-3 p-4">
+            <Github size={18} className="text-slate-700" />
+            <CardDescription>
+              Import one of your GitHub repositories as a NexHub project. You can edit the details later.
+            </CardDescription>
+          </CardBody>
+        </Card>
+
+        {loadError ? (
+          <Card className="border-red-100 bg-red-50/70 shadow-none">
+            <CardBody className="p-4">
+              <CardDescription className="text-red-700">{loadError}</CardDescription>
+            </CardBody>
+          </Card>
+        ) : null}
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8 text-slate-500">
+            <LoaderCircle size={18} className="mr-2 animate-spin" />
+            Loading repositories...
+          </div>
+        ) : repositories.length === 0 ? (
+          <Card className="shadow-none">
+            <CardBody className="p-6 text-center">
+              <CardDescription>No GitHub repositories available to import.</CardDescription>
+            </CardBody>
+          </Card>
+        ) : (
+          <div className="grid gap-3">
+            {repositories.map((repository) => (
+              <Card key={repository.id} className="shadow-none">
+                <CardBody className="flex flex-col gap-4 p-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <CardTitle className="text-lg">{repository.fullName}</CardTitle>
+                      {repository.isPrivate ? (
+                        <Badge variant="secondary">
+                          <Lock size={12} />
+                          Private
+                        </Badge>
+                      ) : (
+                        <Badge variant="secondary">Public</Badge>
+                      )}
+                    </div>
+                    <CardDescription>
+                      {repository.description?.trim() || 'No description provided on GitHub.'}
+                    </CardDescription>
+                    <a
+                      className="inline-flex items-center gap-1 text-sm text-indigo-600 hover:text-indigo-700"
+                      href={repository.htmlUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      View repository
+                      <ExternalLink size={14} />
+                    </a>
+                  </div>
+
+                  <Button
+                    variant="primary"
+                    onClick={() => handleImport(repository)}
+                    disabled={importingRepoId === repository.id}
+                    className="sm:self-center"
+                  >
+                    {importingRepoId === repository.id ? (
+                      <>
+                        <LoaderCircle size={16} className="animate-spin" />
+                        Importing...
+                      </>
+                    ) : (
+                      'Import'
+                    )}
+                  </Button>
+                </CardBody>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/src/lib/auth-storage.ts
+++ b/src/lib/auth-storage.ts
@@ -84,7 +84,7 @@ export async function signup(username: string, email: string, password: string):
   return response.json()
 }
 
-export async function updateAccount(user: User): Promise<ApiResponse<User>> {
+export async function updateAccount(user: User): Promise<ApiResponse<AuthUser>> {
   const response = await fetch(AUTH_UPDATE_ENDPOINT, {
     method: 'POST',
     headers: getAuthHeaders(),

--- a/src/lib/github-storage.ts
+++ b/src/lib/github-storage.ts
@@ -1,0 +1,21 @@
+import type { ApiResponse, GithubRepository } from '../types/app'
+import { readStoredUserToken } from './auth-storage'
+
+const GITHUB_REPOS_ENDPOINT = '/api/github/repos'
+
+function getAuthHeaders(): HeadersInit {
+  const token = readStoredUserToken()
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  }
+}
+
+export async function fetchGithubRepositories(): Promise<ApiResponse<GithubRepository[]>> {
+  const response = await fetch(GITHUB_REPOS_ENDPOINT, {
+    method: 'GET',
+    headers: getAuthHeaders(),
+  })
+
+  return response.json()
+}

--- a/src/pages/auth-page.tsx
+++ b/src/pages/auth-page.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { FormEvent } from 'react'
-import { ArrowRight, CheckCircle2, LoaderCircle, LogIn, Sparkles, UserPlus } from 'lucide-react'
-import { useNavigate } from 'react-router-dom'
+import { ArrowRight, CheckCircle2, Github, LoaderCircle, LogIn, Sparkles, UserPlus } from 'lucide-react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import type { ApiResponse, AuthMode, AuthUser, User } from '../types/app'
 import { BrandMark } from '../components/app/brand-mark'
@@ -66,6 +66,7 @@ export function AuthPage({
   onAuthSuccess: (user: AuthUser) => void
 }) {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const [loginForm, setLoginForm] = useState(initialLogin)
   const [signupForm, setSignupForm] = useState(initialSignup)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -76,6 +77,18 @@ export function AuthPage({
     email?: string
     password?: string
   }>({})
+
+  useEffect(() => {
+    const error = searchParams.get('error')
+    if (!error) {
+      return
+    }
+
+    setFeedback({
+      type: 'error',
+      message: error,
+    })
+  }, [searchParams])
 
   const activeHeading = useMemo(() => {
     return mode === 'login'
@@ -196,6 +209,10 @@ export function AuthPage({
     })
   }
 
+  function handleGithubLogin() {
+    window.location.href = '/api/auth/github/start'
+  }
+
   return (
     <main className="min-h-screen px-4 py-6 sm:px-6 lg:px-8">
       <div className="grid min-h-[calc(100vh-3rem)] gap-8 lg:grid-cols-[minmax(320px,1.15fr)_minmax(340px,440px)] lg:items-center">
@@ -308,6 +325,18 @@ export function AuthPage({
               <Button type="submit" variant="primary" size="lg" className="w-full" disabled={isSubmitting}>
                 {mode === 'login' ? 'Sign in to NexHub' : 'Create account'}
                 {isSubmitting ? <LoaderCircle size={18} className="animate-spin" /> : <ArrowRight size={18} />}
+              </Button>
+
+              <Button
+                type="button"
+                variant="outline"
+                size="lg"
+                className="w-full"
+                disabled={isSubmitting}
+                onClick={handleGithubLogin}
+              >
+                <Github size={18} />
+                Continue with GitHub
               </Button>
             </form>
 

--- a/src/pages/github-auth-callback-page.tsx
+++ b/src/pages/github-auth-callback-page.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { LoaderCircle } from 'lucide-react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import { Card, CardBody, CardDescription, CardTitle } from '../components/ui/card'
+import type { AuthUser } from '../types/app'
+
+export function GithubAuthCallbackPage({
+  onAuthSuccess,
+}: {
+  onAuthSuccess: (user: AuthUser) => void
+}) {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const [message, setMessage] = useState('Finishing GitHub sign in...')
+
+  useEffect(() => {
+    const error = searchParams.get('error')
+    if (error) {
+      navigate(`/auth/login?error=${encodeURIComponent(error)}`, { replace: true })
+      return
+    }
+
+    const token = searchParams.get('token')
+    const id = searchParams.get('id')
+    const username = searchParams.get('username')
+    const email = searchParams.get('email')
+
+    if (!token || !id || !username || !email) {
+      navigate('/auth/login?error=GitHub sign in did not complete correctly.', { replace: true })
+      return
+    }
+
+    onAuthSuccess({
+      token,
+      user: {
+        id: Number(id),
+        username,
+        email,
+        githubId: searchParams.get('githubId') ? Number(searchParams.get('githubId')) : null,
+        githubUsername: searchParams.get('githubUsername'),
+        profileImageUrl: searchParams.get('profileImageUrl'),
+      },
+    })
+
+    setMessage('GitHub connected. Redirecting to your repositories...')
+    navigate('/projects?importGithub=1', { replace: true })
+  }, [navigate, onAuthSuccess, searchParams])
+
+  return (
+    <main className="flex min-h-screen items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
+      <Card className="w-full max-w-lg">
+        <CardBody className="flex flex-col items-center gap-4 p-8 text-center">
+          <LoaderCircle size={28} className="animate-spin text-indigo-600" />
+          <CardTitle>Connecting GitHub</CardTitle>
+          <CardDescription>{message}</CardDescription>
+        </CardBody>
+      </Card>
+    </main>
+  )
+}

--- a/src/pages/profile/profile-tabs/profile.tsx
+++ b/src/pages/profile/profile-tabs/profile.tsx
@@ -13,10 +13,36 @@ import {
   AUTH_DELETE_ENDPOINT,
   AUTH_UPDATE_ENDPOINT,
   readStoredUser,
+  readStoredUserToken,
 } from '../../../lib/auth-storage'
 
 function isValidEmail(value: string) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
+}
+
+async function parseApiResponse<T>(response: Response, fallbackMessage: string): Promise<ApiResponse<T>> {
+  const text = await response.text()
+  if (!text) {
+    return {
+      status: 'error',
+      message: response.status === 401 || response.status === 403
+        ? 'Your session expired. Please sign in again.'
+        : fallbackMessage,
+      data: null,
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  try {
+    return JSON.parse(text) as ApiResponse<T>
+  } catch {
+    return {
+      status: 'error',
+      message: fallbackMessage,
+      data: null,
+      timestamp: new Date().toISOString(),
+    }
+  }
 }
 
 export function ProfileTab({
@@ -54,6 +80,7 @@ export function ProfileTab({
   const [deleteErrors, setDeleteErrors] = useState<{
     currentPassword?: string
   }>({})
+  const isGithubUser = Boolean(user?.githubId || user?.githubUsername)
 
   useEffect(() => {
     const storedUser = readStoredUser()
@@ -88,11 +115,13 @@ export function ProfileTab({
       },
       {
         label: 'Security',
-        value: 'Current password is required to save account changes.',
+        value: isGithubUser
+          ? 'Signed in with GitHub. Password changes are disabled.'
+          : 'Current password is required to save account changes.',
         icon: <Shield size={16} className="text-slate-400" />,
       },
     ],
-    [user]
+    [isGithubUser, user]
   )
 
   if (!user) {
@@ -110,13 +139,21 @@ export function ProfileTab({
     setFeedback(null)
 
     try {
+      const token = readStoredUserToken()
       const response = await fetch(AUTH_UPDATE_ENDPOINT, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          ...form,
+          currentPassword: isGithubUser ? '' : form.currentPassword,
+          newPassword: isGithubUser ? '' : form.newPassword,
+        }),
       })
 
-      const result = (await response.json()) as ApiResponse<AuthUser>
+      const result = await parseApiResponse<AuthUser>(response, 'Unable to update account')
       const data = result.data
 
       if (!response.ok || result.status === 'error' || !data) {
@@ -159,16 +196,20 @@ export function ProfileTab({
     setFeedback(null)
 
     try {
+      const token = readStoredUserToken()
       const response = await fetch(AUTH_DELETE_ENDPOINT, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           email: form.currentEmail,
           password: form.currentPassword,
         }),
       })
 
-      const result = (await response.json()) as ApiResponse<null>
+      const result = await parseApiResponse<null>(response, 'Unable to delete account')
       if (!response.ok || result.status === 'error') {
         throw new Error(result.message || 'Unable to delete account')
       }
@@ -201,7 +242,7 @@ export function ProfileTab({
       nextErrors.currentEmail = 'Enter a valid current email.'
     }
 
-    if (!form.currentPassword.trim()) {
+    if (!isGithubUser && !form.currentPassword.trim()) {
       nextErrors.currentPassword = 'Current password is required.'
     }
 
@@ -215,7 +256,9 @@ export function ProfileTab({
       nextErrors.newEmail = 'Enter a valid new email.'
     }
 
-    if (form.newPassword && form.newPassword.length < 8) {
+    if (isGithubUser && form.newPassword.trim()) {
+      nextErrors.newPassword = 'Password changes are disabled for GitHub accounts.'
+    } else if (form.newPassword && form.newPassword.length < 8) {
       nextErrors.newPassword = 'New password must be at least 8 characters.'
     }
 
@@ -232,6 +275,9 @@ export function ProfileTab({
     }
 
     if (field === 'currentPassword') {
+      if (isGithubUser) {
+        return undefined
+      }
       return value.trim() ? undefined : 'Current password is required.'
     }
 
@@ -244,6 +290,10 @@ export function ProfileTab({
         return 'New email is required.'
       }
       return isValidEmail(value) ? undefined : 'Enter a valid new email.'
+    }
+
+    if (isGithubUser) {
+      return value.trim() ? 'Password changes are disabled for GitHub accounts.' : undefined
     }
 
     return !value || value.length >= 8 ? undefined : 'New password must be at least 8 characters.'
@@ -294,7 +344,7 @@ export function ProfileTab({
               <CardTitle className="text-xl">Profile overview</CardTitle>
               <CardDescription className="text-base leading-7 text-slate-600">
                 Your account information is shown here. Use edit profile when you want to update your username,
-                email, or password.
+                email{isGithubUser ? '.' : ', or password.'}
               </CardDescription>
             </CardBody>
           </Card>
@@ -377,25 +427,27 @@ export function ProfileTab({
               }}
             />
 
-            <Input
-              type="password"
-              label="Current password"
-              helperText={editErrors.currentPassword || 'Required to save changes.'}
-              error={Boolean(editErrors.currentPassword)}
-              value={form.currentPassword}
-              onChange={(event) => {
-                setForm((current) => ({
-                  ...current,
-                  currentPassword: event.target.value,
-                }))
-                updateEditError('currentPassword', event.target.value)
-                if (deleteErrors.currentPassword) {
-                  setDeleteErrors({
-                    currentPassword: event.target.value.trim() ? undefined : 'Current password is required.',
-                  })
-                }
-              }}
-            />
+            {!isGithubUser ? (
+              <Input
+                type="password"
+                label="Current password"
+                helperText={editErrors.currentPassword || 'Required to save changes.'}
+                error={Boolean(editErrors.currentPassword)}
+                value={form.currentPassword}
+                onChange={(event) => {
+                  setForm((current) => ({
+                    ...current,
+                    currentPassword: event.target.value,
+                  }))
+                  updateEditError('currentPassword', event.target.value)
+                  if (deleteErrors.currentPassword) {
+                    setDeleteErrors({
+                      currentPassword: event.target.value.trim() ? undefined : 'Current password is required.',
+                    })
+                  }
+                }}
+              />
+            ) : null}
 
             <Input
               label="New username"
@@ -426,20 +478,22 @@ export function ProfileTab({
               }}
             />
 
-            <Input
-              type="password"
-              label="New password"
-              helperText={editErrors.newPassword || 'Leave empty to keep the current one.'}
-              error={Boolean(editErrors.newPassword)}
-              value={form.newPassword}
-              onChange={(event) => {
-                setForm((current) => ({
-                  ...current,
-                  newPassword: event.target.value,
-                }))
-                updateEditError('newPassword', event.target.value)
-              }}
-            />
+            {!isGithubUser ? (
+              <Input
+                type="password"
+                label="New password"
+                helperText={editErrors.newPassword || 'Leave empty to keep the current one.'}
+                error={Boolean(editErrors.newPassword)}
+                value={form.newPassword}
+                onChange={(event) => {
+                  setForm((current) => ({
+                    ...current,
+                    newPassword: event.target.value,
+                  }))
+                  updateEditError('newPassword', event.target.value)
+                }}
+              />
+            ) : null}
 
             <div className="flex justify-end gap-3 pt-2">
               <Button type="button" variant="ghost" onClick={() => setIsEditOpen(false)}>

--- a/src/pages/profile/profile-tabs/projects.tsx
+++ b/src/pages/profile/profile-tabs/projects.tsx
@@ -53,6 +53,21 @@ export function ProjectsTab() {
     tags: []
   });
 
+  function resetProjectForm() {
+    setCreateErrors({})
+    setTagsInput('')
+    setFeedback(null)
+    setIsSubmitting(false)
+    setProjectForm({
+      name: "",
+      ownerId: 0,
+      description: "",
+      githubRepo: "",
+      status: "",
+      tags: []
+    })
+  }
+
   const reloadProjects = async (pageOverride = currentPage) => {
     setIsLoadingProjects(true)
     const response = await fetchProjectsByCurrentUser({
@@ -163,6 +178,7 @@ export function ProjectsTab() {
         setIsSubmitting(false)
         setFeedback({message: "Project created successfully", type:"success"});
         setShowModal(false)
+        resetProjectForm()
         setCurrentPage(0)
         void reloadProjects(0)
       })
@@ -179,16 +195,7 @@ export function ProjectsTab() {
         isOpen={showModal}
         onClose={() => {
           setShowModal(false)
-          setCreateErrors({})
-          setTagsInput('')
-          setProjectForm({
-            name: "",
-            ownerId: 0,
-            description: "",
-            githubRepo: "",
-            status: "",
-            tags: []
-          })
+          resetProjectForm()
         }}
         title={"Create a new project"}
       >
@@ -282,7 +289,14 @@ export function ProjectsTab() {
             onChange={(event) => setTagsInput(event.target.value)}
           />
           <div className="flex justify-end gap-3 pt-2">
-            <Button type="button" variant="ghost" onClick={() => setShowModal(false)}>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                setShowModal(false)
+                resetProjectForm()
+              }}
+            >
               Cancel
             </Button>
             <Button type="submit" variant="primary" disabled={isSubmitting}>
@@ -308,7 +322,10 @@ export function ProjectsTab() {
             className="h-12 mr-10"
             variant="primary"
             size="lg"
-            onClick={() => setShowModal(true)}
+            onClick={() => {
+              resetProjectForm()
+              setShowModal(true)
+            }}
           >
             <PlusIcon size={16} />
           </Button>
@@ -347,11 +364,11 @@ export function ProjectsTab() {
                     clickMouse={true}
                   >
                     <CardBody className="flex h-full flex-col gap-4 p-5">
-                      <div className="min-h-[5rem] space-y-2">
-                        <CardTitle className="text-2xl font-medium">
+                      <div className="min-h-[5rem] min-w-0 space-y-2">
+                        <CardTitle className="break-words text-2xl font-medium leading-tight">
                           {project.name}
                         </CardTitle>
-                        <CardDescription>{project.description}</CardDescription>
+                        <CardDescription className="break-words">{project.description}</CardDescription>
                       </div>
                       <div className="flex flex-wrap gap-2">
                         {project.tags.map((tag) => (

--- a/src/pages/projects-page.tsx
+++ b/src/pages/projects-page.tsx
@@ -1,6 +1,7 @@
-import { ArrowLeft, PlusIcon, Search, Star, Users } from 'lucide-react'
+import { ArrowLeft, Github, PlusIcon, Search, Star, Users } from 'lucide-react'
 
 import { AppHeader } from '../components/app/app-header'
+import { ImportGithubReposModal } from '../components/app/import-github-repos-modal'
 import { StatLine } from '../components/app/stat-line'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
@@ -8,7 +9,7 @@ import { Card, CardBody, CardDescription, CardTitle } from '../components/ui/car
 import { Input } from '../components/ui/input'
 import { PaginationControls } from '../components/ui/pagination-controls'
 import { CreateProjectModal } from '../components/app/create-project-modal'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { fetchAllProjects } from '../lib/project-storage'
 import { useEffect, useState } from 'react'
 import type { PaginatedResponse, ProjectResponse } from '../types/app'
@@ -23,6 +24,7 @@ export function ProjectsPage({
   onOpenMenu: () => void
 }) {
   const navigator = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [projectsPage, setProjectsPage] = useState<PaginatedResponse<ProjectResponse>>(
     createEmptyPaginatedResponse<ProjectResponse>(0, GRID_PAGE_SIZE),
   )
@@ -30,35 +32,47 @@ export function ProjectsPage({
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const [showImportModal, setShowImportModal] = useState(false)
   const [feedback, setFeedback] = useState<string | null>(null)
   const currentUser = readStoredUser()
 
-  useEffect(() => {
-    const loadProjects = async () => {
-      setIsLoading(true)
-      setLoadError(null)
+  async function loadProjects(page: number) {
+    setIsLoading(true)
+    setLoadError(null)
 
+    try {
       const response = await fetchAllProjects({
-        page: currentPage,
+        page,
         size: GRID_PAGE_SIZE,
       })
 
       if (response.status === 'success' && response.data) {
         setProjectsPage(response.data)
       } else {
-        setProjectsPage(createEmptyPaginatedResponse<ProjectResponse>(currentPage, GRID_PAGE_SIZE))
+        setProjectsPage(createEmptyPaginatedResponse<ProjectResponse>(page, GRID_PAGE_SIZE))
         setLoadError(response.message || 'Unable to load projects.')
       }
-
+    } catch (error) {
+      console.error(error)
+      setProjectsPage(createEmptyPaginatedResponse<ProjectResponse>(page, GRID_PAGE_SIZE))
+      setLoadError('Unable to load projects.')
+    } finally {
       setIsLoading(false)
     }
-    loadProjects().catch((error) => {
+  }
+
+  useEffect(() => {
+    loadProjects(currentPage).catch((error) => {
       console.error(error)
-      setProjectsPage(createEmptyPaginatedResponse<ProjectResponse>(currentPage, GRID_PAGE_SIZE))
-      setLoadError('Unable to load projects.')
-      setIsLoading(false)
     })
   }, [currentPage])
+
+  useEffect(() => {
+    if (searchParams.get('importGithub') === '1' && currentUser?.githubUsername) {
+      setShowImportModal(true)
+      setSearchParams({}, { replace: true })
+    }
+  }, [currentUser?.githubUsername, searchParams, setSearchParams])
 
   return (
     <main className="min-h-screen px-4 py-5 sm:px-6 lg:px-8">
@@ -79,14 +93,27 @@ export function ProjectsPage({
                 </CardDescription>
               </div>
               {currentUser ? (
-                <Button
-                  className="h-12"
-                  variant="primary"
-                  size="lg"
-                  onClick={() => setShowCreateModal(true)}
-                >
-                  <PlusIcon size={16} />
-                </Button>
+                <div className="flex items-center gap-3">
+                  {currentUser.githubUsername ? (
+                    <Button
+                      className="h-12"
+                      variant="outline"
+                      size="lg"
+                      onClick={() => setShowImportModal(true)}
+                    >
+                      <Github size={16} />
+                      Import repos
+                    </Button>
+                  ) : null}
+                  <Button
+                    className="h-12"
+                    variant="primary"
+                    size="lg"
+                    onClick={() => setShowCreateModal(true)}
+                  >
+                    <PlusIcon size={16} />
+                  </Button>
+                </div>
               ) : null}
             </div>
             {feedback ? (
@@ -102,16 +129,16 @@ export function ProjectsPage({
               onCreated={async () => {
                 setFeedback('Project created successfully.')
                 setCurrentPage(0)
-                setIsLoading(true)
-                setLoadError(null)
-                const response = await fetchAllProjects({ page: 0, size: GRID_PAGE_SIZE })
-                if (response.status === 'success' && response.data) {
-                  setProjectsPage(response.data)
-                } else {
-                  setProjectsPage(createEmptyPaginatedResponse<ProjectResponse>(0, GRID_PAGE_SIZE))
-                  setLoadError(response.message || 'Unable to load projects.')
-                }
-                setIsLoading(false)
+                await loadProjects(0)
+              }}
+            />
+            <ImportGithubReposModal
+              isOpen={showImportModal}
+              onClose={() => setShowImportModal(false)}
+              onImported={async () => {
+                setFeedback('GitHub repository imported successfully.')
+                setCurrentPage(0)
+                await loadProjects(0)
               }}
             />
 

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -8,6 +8,9 @@ export type User = {
   id: number
   username: string
   email: string
+  githubId?: number | null
+  githubUsername?: string | null
+  profileImageUrl?: string | null
 }
 export type ApiResponse<T> = {
   status: 'success' | 'error'
@@ -35,6 +38,15 @@ export type PaginationParams = {
 }
 
 export type AppRoute = '/' | '/auth/login' | '/auth/signup' | '/profile' | '/projects'
+
+export type GithubRepository = {
+  id: number
+  name: string
+  fullName: string
+  description: string | null
+  htmlUrl: string
+  isPrivate: boolean
+}
 
 export type ProjectResponse = {
   id: number,


### PR DESCRIPTION
 Added Continue with GitHub login flow.
- Added GitHub OAuth callback page.
- Added GitHub repository loading and import modal.
- Added Import repos action on Projects page.
- Hid password fields for GitHub-linked users in profile edit.
- Added safer profile update/delete error handling.
- Fixed long project names overflowing profile project cards.
- Reset create-project form when opening/closing the modal.
