### PR TITLE
71 task colaborativas

### DIFF
--- a/src/components/app/create-task-modal.tsx
+++ b/src/components/app/create-task-modal.tsx
@@ -18,6 +18,7 @@ const EMPTY_TASK_FORM: TaskRequest = {
   deadline: new Date(),
   status: 'Open',
   maxAttempts: 3,
+  collaborative: false,
   recommendedSkills: [],
 }
 
@@ -280,6 +281,23 @@ export function CreateTaskModal({
               updateTaskError('deliverables', event.target.value)
             }}
           />
+        </div>
+        <div className="flex items-center gap-2 mt-6">
+          <input
+            id="sidebar-create-task-collaborative"
+            type="checkbox"
+            checked={taskForm.collaborative}
+            onChange={(event) => {
+              setTaskForm((current) => ({
+                ...current,
+                collaborative: event.target.checked,
+              }))
+            }}
+            className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+          />
+          <label htmlFor="sidebar-create-task-collaborative" className="text-sm font-medium text-slate-700 cursor-pointer">
+            Collaborative Task
+          </label>
         </div>
         <div className="md:col-span-2">
           <label className="mb-2 block text-sm font-medium">Recommended Skills</label>

--- a/src/components/app/create-task-modal.tsx
+++ b/src/components/app/create-task-modal.tsx
@@ -32,6 +32,7 @@ export function CreateTaskModal({
   onCreated?: () => void | Promise<void>
 }) {
   const [taskForm, setTaskForm] = useState<TaskRequest>(EMPTY_TASK_FORM)
+  const [allowAnyReputation, setAllowAnyReputation] = useState(true)
   const [projects, setProjects] = useState<ProjectResponse[]>([])
   const [skillsInput, setSkillsInput] = useState('')
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -72,6 +73,7 @@ export function CreateTaskModal({
 
   function resetForm() {
     setTaskForm(EMPTY_TASK_FORM)
+    setAllowAnyReputation(true)
     setProjects([])
     setSkillsInput('')
     setSubmitError(null)
@@ -150,6 +152,7 @@ export function CreateTaskModal({
 
       const result = await createTask({
         ...taskForm,
+        minReputation: allowAnyReputation ? -500 : (taskForm.minReputation || 0),
         recommendedSkills: skillsInput
           .split(',')
           .map((skill) => skill.trim())
@@ -299,6 +302,45 @@ export function CreateTaskModal({
             Collaborative Task
           </label>
         </div>
+        <div className="flex flex-col justify-center gap-2">
+          <div className="flex items-center gap-2">
+            <input
+              id="sidebar-create-task-any-rep"
+              type="checkbox"
+              checked={allowAnyReputation}
+              onChange={(event) => {
+                const checked = event.target.checked
+                setAllowAnyReputation(checked)
+                if (checked) {
+                  setTaskForm((current) => ({ ...current, minReputation: -500 }))
+                } else {
+                  setTaskForm((current) => ({ ...current, minReputation: 0 }))
+                }
+              }}
+              className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+            />
+            <label htmlFor="sidebar-create-task-any-rep" className="text-sm font-medium text-slate-700 cursor-pointer">
+              Any reputation score
+            </label>
+          </div>
+        </div>
+        {!allowAnyReputation && (
+          <div>
+            <label className="mb-2 block text-sm font-medium">Minimum Reputation Required</label>
+            <Input
+              type="number"
+              placeholder="0"
+              value={taskForm.minReputation === undefined ? '' : taskForm.minReputation}
+              onChange={(event) => {
+                const value = event.target.value
+                setTaskForm((current) => ({
+                  ...current,
+                  minReputation: value === '' ? 0 : Number(value),
+                }))
+              }}
+            />
+          </div>
+        )}
         <div className="md:col-span-2">
           <label className="mb-2 block text-sm font-medium">Recommended Skills</label>
           <Input

--- a/src/lib/task-invitation-storage.ts
+++ b/src/lib/task-invitation-storage.ts
@@ -1,0 +1,95 @@
+import type {
+  ApiResponse,
+  PaginatedResponse,
+  PaginationParams,
+  TaskInvitationRequest,
+  TaskInvitationResponse,
+} from '../types/app'
+import { readStoredUserToken, handleForbiddenResponse } from './auth-storage'
+import { buildPaginationQuery, normalizePaginatedApiResponse } from './pagination'
+
+const INVITATION_ROOT_ENDPOINT = '/api/task-invitations'
+export const GET_PENDING_INVITATIONS_ENDPOINT = INVITATION_ROOT_ENDPOINT + '/pending'
+export const GET_INVITATIONS_BY_TASK_ENDPOINT = (taskId: number) => INVITATION_ROOT_ENDPOINT + '/task/' + String(taskId)
+export const ACCEPT_INVITATION_ENDPOINT = (id: number) => `${INVITATION_ROOT_ENDPOINT}/${id}/accept`
+export const REJECT_INVITATION_ENDPOINT = (id: number) => `${INVITATION_ROOT_ENDPOINT}/${id}/reject`
+
+function getAuthHeaders(): HeadersInit {
+  const token = readStoredUserToken()
+  return {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+  }
+}
+
+function handleResponse(response: Response) {
+  if (response.status === 403) {
+    handleForbiddenResponse()
+  }
+  return response.json()
+}
+
+export async function createInvitation(request: TaskInvitationRequest): Promise<ApiResponse<TaskInvitationResponse>> {
+  const response = await fetch(INVITATION_ROOT_ENDPOINT, {
+    method: 'POST',
+    headers: getAuthHeaders(),
+    body: JSON.stringify(request),
+  })
+  return handleResponse(response)
+}
+
+export async function acceptInvitation(id: number): Promise<ApiResponse<TaskInvitationResponse>> {
+  const response = await fetch(ACCEPT_INVITATION_ENDPOINT(id), {
+    method: 'PUT',
+    headers: getAuthHeaders(),
+  })
+  return handleResponse(response)
+}
+
+export async function rejectInvitation(id: number): Promise<ApiResponse<TaskInvitationResponse>> {
+  const response = await fetch(REJECT_INVITATION_ENDPOINT(id), {
+    method: 'PUT',
+    headers: getAuthHeaders(),
+  })
+  return handleResponse(response)
+}
+
+export async function fetchPendingInvitations(
+  params?: PaginationParams,
+): Promise<ApiResponse<PaginatedResponse<TaskInvitationResponse>>> {
+  const token = readStoredUserToken()
+  if (!token) {
+    return {
+      status: 'error',
+      message: 'No authentication token',
+      data: null,
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  const page = params?.page ?? 0
+  const size = params?.size ?? 10
+  const response = await fetch(`${GET_PENDING_INVITATIONS_ENDPOINT}${buildPaginationQuery(params)}`, {
+    method: 'GET',
+    headers: getAuthHeaders(),
+  })
+  return normalizePaginatedApiResponse(await handleResponse(response), page, size)
+}
+
+export async function fetchInvitationsByTask(taskId: number): Promise<ApiResponse<TaskInvitationResponse[]>> {
+  const token = readStoredUserToken()
+  if (!token) {
+    return {
+      status: 'error',
+      message: 'No authentication token',
+      data: null,
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  const response = await fetch(GET_INVITATIONS_BY_TASK_ENDPOINT(taskId), {
+    method: 'GET',
+    headers: getAuthHeaders(),
+  })
+  return handleResponse(response)
+}

--- a/src/pages/profile/profile-tabs/assigned-tasks.tsx
+++ b/src/pages/profile/profile-tabs/assigned-tasks.tsx
@@ -7,7 +7,8 @@ import { Button } from '../../../components/ui/button'
 import { Card, CardBody, CardDescription, CardTitle } from '../../../components/ui/card'
 import { PaginationControls } from '../../../components/ui/pagination-controls'
 import { fetchAssignmentsByUser } from '../../../lib/assignment-storage'
-import type { PaginatedResponse, TaskAssignmentResponse, User } from '../../../types/app'
+import { fetchPendingInvitations, acceptInvitation, rejectInvitation } from '../../../lib/task-invitation-storage'
+import type { PaginatedResponse, TaskAssignmentResponse, User, TaskInvitationResponse } from '../../../types/app'
 import { PROFILE_PAGE_SIZE, createEmptyPaginatedResponse } from '../../../lib/pagination'
 import { readStoredProfileDashboard } from '../../../lib/dashboard-storage'
 
@@ -36,6 +37,18 @@ export function AssignedTasksTab({
   const [currentPage, setCurrentPage] = useState(0)
   const [isLoading, setIsLoading] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
+  const [pendingInvites, setPendingInvites] = useState<TaskInvitationResponse[]>([])
+
+  const loadInvitations = useCallback(async () => {
+    try {
+      const response = await fetchPendingInvitations({ page: 0, size: 50 })
+      if (response.status === 'success' && response.data) {
+        setPendingInvites(response.data.content)
+      }
+    } catch (error) {
+      console.error('Failed to load pending invitations', error)
+    }
+  }, [])
 
   const loadAssignedTasks = useCallback(async (pageOverride = currentPage) => {
     if (!user?.id) return;
@@ -69,6 +82,39 @@ export function AssignedTasksTab({
     }
   }, [user.id, currentPage]);
 
+  const handleAcceptInvite = async (inviteId: number) => {
+    try {
+      setIsLoading(true)
+      const res = await acceptInvitation(inviteId)
+      if (res.status === 'success') {
+        setPendingInvites(prev => prev.filter(i => i.id !== inviteId))
+        await loadAssignedTasks(currentPage)
+      } else {
+        alert(res.message || 'Failed to accept invitation')
+      }
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleRejectInvite = async (inviteId: number) => {
+    try {
+      setIsLoading(true)
+      const res = await rejectInvitation(inviteId)
+      if (res.status === 'success') {
+        setPendingInvites(prev => prev.filter(i => i.id !== inviteId))
+      } else {
+        alert(res.message || 'Failed to reject invitation')
+      }
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   useEffect(() => {
     const syncFromDashboard = () => {
       const dashboard = readStoredProfileDashboard();
@@ -82,10 +128,11 @@ export function AssignedTasksTab({
     } else {
       syncFromDashboard();
     }
+    void loadInvitations();
 
     window.addEventListener('nexhub-dashboard-updated', syncFromDashboard);
     return () => window.removeEventListener('nexhub-dashboard-updated', syncFromDashboard);
-  }, [loadAssignedTasks, currentPage]);
+  }, [loadAssignedTasks, loadInvitations, currentPage]);
 
   return (
     <Card>
@@ -97,11 +144,59 @@ export function AssignedTasksTab({
               Tasks you chose to work on and still need to finish.
             </CardDescription>
           </div>
-          <Button variant="outline" size="sm" onClick={() => void loadAssignedTasks(currentPage)} disabled={isLoading}>
+          <Button variant="outline" size="sm" onClick={() => { void loadAssignedTasks(currentPage); void loadInvitations(); }} disabled={isLoading}>
             <RefreshCw size={14} className={isLoading ? "animate-spin mr-2" : "mr-2"} />
             Refresh
           </Button>
         </section>
+
+        {pendingInvites.length > 0 && (
+          <section className="space-y-3 p-4 bg-blue-50/50 border border-blue-200/60 rounded-2xl animate-in fade-in slide-in-from-top-4 duration-300">
+            <h3 className="text-lg font-bold text-blue-900 flex items-center gap-2">
+              <span className="relative flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75"></span>
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500"></span>
+              </span>
+              Cooperation Invitations ({pendingInvites.length})
+            </h3>
+            <p className="text-xs text-slate-500">Other developers have invited you to collaborate on their tasks:</p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-2">
+              {pendingInvites.map((invite) => (
+                <Card key={invite.id} className="shadow-none border border-blue-100 bg-white">
+                  <CardBody className="p-4 space-y-3">
+                    <div className="text-slate-900">
+                      <h4 className="font-semibold text-slate-900 line-clamp-1">{invite.taskTitle}</h4>
+                      <p className="text-xs text-slate-500 mt-0.5">Project: {invite.projectName}</p>
+                      <p className="text-xs text-slate-500 mt-1">
+                        Invited by <span className="font-semibold text-slate-700">{invite.senderUsername}</span>
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        onClick={() => handleAcceptInvite(invite.id)}
+                        className="h-8 text-xs font-semibold bg-blue-600 hover:bg-blue-700 text-white"
+                        disabled={isLoading}
+                      >
+                        Accept
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleRejectInvite(invite.id)}
+                        className="h-8 text-xs font-semibold border-slate-200 text-slate-600 hover:bg-slate-50"
+                        disabled={isLoading}
+                      >
+                        Decline
+                      </Button>
+                    </div>
+                  </CardBody>
+                </Card>
+              ))}
+            </div>
+          </section>
+        )}
 
         {loadError ? (
           <Card className="border-red-100 bg-red-50/70 shadow-none">

--- a/src/pages/profile/profile-tabs/tasks.tsx
+++ b/src/pages/profile/profile-tabs/tasks.tsx
@@ -59,6 +59,7 @@ export function TasksTab({
     return dashboard?.tasks || createEmptyPaginatedResponse<TaskResponse>(0, PROFILE_PAGE_SIZE);
   });
   const [currentPage, setCurrentPage] = useState(0);
+  const [allowAnyReputation, setAllowAnyReputation] = useState(true);
   const [isLoadingTasks, setIsLoadingTasks] = useState(false);
   const [showModal, setShowModal] = useState<boolean>(false);
   const [isEditMode, setIsEditMode] = useState(false);
@@ -207,6 +208,7 @@ export function TasksTab({
 
     const taskData = {
       ...taskForm,
+      minReputation: allowAnyReputation ? -500 : (taskForm.minReputation || 0),
       recommendedSkills: skillsInput
         .split(',')
         .map((skill) => skill.trim())
@@ -281,9 +283,11 @@ export function TasksTab({
       status: task.status,
       maxAttempts: task.maxAttempts,
       collaborative: task.collaborative,
+      minReputation: task.minReputation,
       recommendedSkills: task.recommendedSkills
     })
     setSkillsInput(task.recommendedSkills.join(', '))
+    setAllowAnyReputation(!task.minReputation || task.minReputation <= -500)
     setEditingTaskId(task.id)
     setIsEditMode(true)
     setShowModal(true)
@@ -295,6 +299,7 @@ export function TasksTab({
     setEditingTaskId(null)
     setCreateErrors({})
     setSkillsInput('')
+    setAllowAnyReputation(true)
     setTaskForm(EMPTY_TASK_FORM)
   }
 
@@ -462,6 +467,51 @@ export function TasksTab({
               Collaborative Task
             </label>
           </div>
+          <div className="flex flex-col justify-center gap-2">
+            <div className="flex items-center gap-2 mt-6">
+              <input
+                id="tab-create-task-any-rep"
+                type="checkbox"
+                checked={allowAnyReputation}
+                onChange={(event) => {
+                  const checked = event.target.checked;
+                  setAllowAnyReputation(checked);
+                  if (checked) {
+                    setTaskForm((current) => ({
+                      ...current,
+                      minReputation: -500,
+                    }));
+                  } else {
+                    setTaskForm((current) => ({
+                      ...current,
+                      minReputation: 0,
+                    }));
+                  }
+                }}
+                className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+              />
+              <label htmlFor="tab-create-task-any-rep" className="text-sm font-medium text-slate-700 cursor-pointer">
+                Any reputation score
+              </label>
+            </div>
+          </div>
+          {!allowAnyReputation && (
+            <div>
+              <label className="block text-sm font-medium mb-2">Minimum Reputation Required</label>
+              <Input
+                type="number"
+                placeholder="0"
+                value={taskForm.minReputation === undefined ? "" : taskForm.minReputation}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setTaskForm((current) => ({
+                    ...current,
+                    minReputation: value === "" ? 0 : Number(value),
+                  }));
+                }}
+              />
+            </div>
+          )}
 
           <div className="md:col-span-2">
             <label className="block text-sm font-medium mb-2">Recommended Skills</label>

--- a/src/pages/profile/profile-tabs/tasks.tsx
+++ b/src/pages/profile/profile-tabs/tasks.tsx
@@ -41,6 +41,7 @@ const EMPTY_TASK_FORM: TaskRequest = {
   deadline: new Date(),
   status: "Open",
   maxAttempts: 3,
+  collaborative: false,
   recommendedSkills: []
 }
 
@@ -279,6 +280,7 @@ export function TasksTab({
       deadline: task.deadline,
       status: task.status,
       maxAttempts: task.maxAttempts,
+      collaborative: task.collaborative,
       recommendedSkills: task.recommendedSkills
     })
     setSkillsInput(task.recommendedSkills.join(', '))
@@ -442,6 +444,23 @@ export function TasksTab({
                 updateTaskError('deliverables', event.target.value)
               }}
             />
+          </div>
+          <div className="flex items-center gap-2 mt-6">
+            <input
+              id="tab-create-task-collaborative"
+              type="checkbox"
+              checked={taskForm.collaborative}
+              onChange={(event) => {
+                setTaskForm((current) => ({
+                  ...current,
+                  collaborative: event.target.checked,
+                }))
+              }}
+              className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+            />
+            <label htmlFor="tab-create-task-collaborative" className="text-sm font-medium text-slate-700 cursor-pointer">
+              Collaborative Task
+            </label>
           </div>
 
           <div className="md:col-span-2">

--- a/src/pages/project-detail-page.tsx
+++ b/src/pages/project-detail-page.tsx
@@ -116,6 +116,7 @@ export function ProjectDetailPage({
 
   // State for creating a new task
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [allowAnyReputation, setAllowAnyReputation] = useState(true);
   const [newTaskForm, setNewTaskForm] = useState<TaskRequest>({
     projectId: 0,
     title: "",
@@ -224,6 +225,7 @@ export function ProjectDetailPage({
     setCreateSkillsInput("");
     setCreateErrors({});
     setCreateFeedback(null);
+    setAllowAnyReputation(true);
     setShowCreateModal(true);
   };
 
@@ -240,6 +242,7 @@ export function ProjectDetailPage({
 
     const taskData = {
       ...newTaskForm,
+      minReputation: allowAnyReputation ? -500 : (newTaskForm.minReputation || 0),
       recommendedSkills: createSkillsInput
         .split(",")
         .map((skill) => skill.trim())
@@ -1111,21 +1114,52 @@ export function ProjectDetailPage({
                     />
                   </div>
 
-                  <div>
-                    <label className="block text-sm font-medium mb-1 text-slate-700">Minimum Reputation Required</label>
-                    <Input
-                      type="number"
-                      placeholder="0"
-                      value={newTaskForm.minReputation === undefined ? "" : newTaskForm.minReputation}
-                      onChange={(event) => {
-                        const value = event.target.value;
-                        setNewTaskForm((current) => ({
-                          ...current,
-                          minReputation: value === "" ? 0 : Number(value),
-                        }));
-                      }}
-                    />
+                  <div className="flex flex-col justify-center gap-2">
+                    <div className="flex items-center gap-2 mt-6">
+                      <input
+                        id="project-create-task-any-rep"
+                        type="checkbox"
+                        checked={allowAnyReputation}
+                        onChange={(event) => {
+                          const checked = event.target.checked;
+                          setAllowAnyReputation(checked);
+                          if (checked) {
+                            setNewTaskForm((current) => ({
+                              ...current,
+                              minReputation: -500,
+                            }));
+                          } else {
+                            setNewTaskForm((current) => ({
+                              ...current,
+                              minReputation: 0,
+                            }));
+                          }
+                        }}
+                        className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                      />
+                      <label htmlFor="project-create-task-any-rep" className="text-sm font-medium text-slate-700 cursor-pointer">
+                        Any reputation score
+                      </label>
+                    </div>
                   </div>
+
+                  {!allowAnyReputation && (
+                    <div>
+                      <label className="block text-sm font-medium mb-1 text-slate-700">Minimum Reputation Required</label>
+                      <Input
+                        type="number"
+                        placeholder="0"
+                        value={newTaskForm.minReputation === undefined ? "" : newTaskForm.minReputation}
+                        onChange={(event) => {
+                          const value = event.target.value;
+                          setNewTaskForm((current) => ({
+                            ...current,
+                            minReputation: value === "" ? 0 : Number(value),
+                          }));
+                        }}
+                      />
+                    </div>
+                  )}
 
                   <div className="flex items-center gap-2 mt-6">
                     <input

--- a/src/pages/project-detail-page.tsx
+++ b/src/pages/project-detail-page.tsx
@@ -127,6 +127,7 @@ export function ProjectDetailPage({
     status: "OPEN",
     maxAttempts: 3,
     minReputation: 0,
+    collaborative: false,
     recommendedSkills: [],
   });
   const [createSkillsInput, setCreateSkillsInput] = useState("");
@@ -217,6 +218,7 @@ export function ProjectDetailPage({
       status: "OPEN",
       maxAttempts: 3,
       minReputation: 0,
+      collaborative: false,
       recommendedSkills: [],
     });
     setCreateSkillsInput("");
@@ -1123,6 +1125,24 @@ export function ProjectDetailPage({
                         }));
                       }}
                     />
+                  </div>
+
+                  <div className="flex items-center gap-2 mt-6">
+                    <input
+                      id="project-create-task-collaborative"
+                      type="checkbox"
+                      checked={newTaskForm.collaborative}
+                      onChange={(event) => {
+                        setNewTaskForm((current) => ({
+                          ...current,
+                          collaborative: event.target.checked,
+                        }));
+                      }}
+                      className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <label htmlFor="project-create-task-collaborative" className="text-sm font-medium text-slate-700 cursor-pointer">
+                      Collaborative Task
+                    </label>
                   </div>
 
                   <div className="md:col-span-2">

--- a/src/pages/task-detail-page.tsx
+++ b/src/pages/task-detail-page.tsx
@@ -661,6 +661,27 @@ export function TaskDetailPage({
   const showChat = !!(currentUser && (userAssignment || isOwner))
   const assignmentButton = getAssignmentButtonContent()
   const submitButton = getSubmitButtonContent()
+
+  const teamLeadId = userAssignment
+    ? (userAssignment.parentAssignmentId || userAssignment.id)
+    : (isOwner && selectedAssignment)
+      ? (selectedAssignment.parentAssignmentId || selectedAssignment.id)
+      : null
+
+  const leadAssignment = teamLeadId
+    ? assignments.find((ass) => ass.id === teamLeadId)
+    : null
+
+  const leadUserId = leadAssignment ? leadAssignment.userId : null
+
+  const teamAssignments = teamLeadId
+    ? assignments.filter((ass) => ass.id === teamLeadId || ass.parentAssignmentId === teamLeadId)
+    : []
+
+  const teamInvitations = leadUserId
+    ? invitations.filter((invite) => invite.senderId === leadUserId)
+    : []
+
   const backTo = typeof location.state === 'object' && location.state !== null && 'backTo' in location.state
     ? String(location.state.backTo)
     : null
@@ -897,11 +918,11 @@ export function TaskDetailPage({
                         {/* Assignees List */}
                         <div>
                           <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">Assigned Developers</h4>
-                          {assignments.length === 0 ? (
+                          {teamAssignments.length === 0 ? (
                             <p className="text-sm text-slate-500 italic">No developers assigned yet.</p>
                           ) : (
                             <div className="flex flex-wrap gap-3">
-                              {assignments.map((ass) => {
+                              {teamAssignments.map((ass) => {
                                 const isLead = !ass.parentAssignmentId
                                 return (
                                   <div
@@ -931,11 +952,11 @@ export function TaskDetailPage({
                         {(isOwner || (userAssignment && !userAssignment.parentAssignmentId)) && (
                           <div className="pt-2 border-t border-slate-100">
                             <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">Sent Invitations</h4>
-                            {invitations.length === 0 ? (
+                            {teamInvitations.length === 0 ? (
                               <p className="text-sm text-slate-500 italic">No invitations sent yet.</p>
                             ) : (
                               <div className="space-y-2">
-                                {invitations.map((invite) => {
+                                {teamInvitations.map((invite) => {
                                   const statusLower = invite.status.toLowerCase()
                                   let statusClass = "bg-amber-50 text-amber-700 border-amber-200"
                                   if (statusLower === 'accepted') statusClass = "bg-green-50 text-green-700 border-green-200"

--- a/src/pages/task-detail-page.tsx
+++ b/src/pages/task-detail-page.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState, type FormEvent } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 
 import { AppHeader } from '../components/app/app-header'
-import type { TaskResponse, User, TaskAssignmentResponse, TaskSubmissionResponse, TaskRequest } from '../types/app'
+import type { TaskResponse, User, TaskAssignmentResponse, TaskSubmissionResponse, TaskRequest, TaskInvitationResponse } from '../types/app'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
 import { Card, CardBody, CardDescription, CardTitle } from '../components/ui/card'
@@ -12,8 +12,9 @@ import { Input } from '../components/ui/input'
 import { fetchProjectById } from '../lib/project-storage'
 import { fetchTaskById, updateTask } from '../lib/task-storage'
 import { createSubmission, fetchSubmissionsByTask, fetchSubmissionsByAssignment, updateSubmission } from '../lib/submission-storage'
-
 import { fetchAssignmentsByUser, createAssignment } from '../lib/assignment-storage'
+import { createInvitation, fetchInvitationsByTask } from '../lib/task-invitation-storage'
+import { fetchAllUsers } from '../lib/user-storage'
 import { LOOKUP_PAGE_SIZE } from '../lib/pagination'
 import { fetchTaskAssignments } from '../lib/chat-storage'
 import { TaskChatPanel } from '../components/app/task-chat-panel'
@@ -67,6 +68,14 @@ export function TaskDetailPage({
   const [isSubmittingReview, setIsSubmittingReview] = useState(false)
   const [reviewError, setReviewError] = useState<string | null>(null)
   const [selectedDeveloperFilter, setSelectedDeveloperFilter] = useState<string | null>(null)
+
+  // State for task collaboration & invitation
+  const [invitations, setInvitations] = useState<TaskInvitationResponse[]>([])
+  const [showInviteModal, setShowInviteModal] = useState(false)
+  const [inviteReceiverId, setInviteReceiverId] = useState<number | null>(null)
+  const [isInviting, setIsInviting] = useState(false)
+  const [inviteError, setInviteError] = useState<string | null>(null)
+  const [allUsers, setAllUsers] = useState<User[]>([])
 
   // State for task editing
   const [showEditModal, setShowEditModal] = useState(false)
@@ -271,6 +280,51 @@ export function TaskDetailPage({
 
 
   useEffect(() => {
+    if (showInviteModal) {
+      async function loadUsers() {
+        try {
+          const res = await fetchAllUsers()
+          if (res.status === 'success' && res.data) {
+            setAllUsers(res.data)
+          }
+        } catch (e) {
+          console.error("Failed to load users for invitation", e)
+        }
+      }
+      void loadUsers()
+    }
+  }, [showInviteModal])
+
+  const handleSendInvitation = async () => {
+    if (!currentUser || !task || !inviteReceiverId) return
+
+    try {
+      setIsInviting(true)
+      setInviteError(null)
+      const res = await createInvitation({
+        taskId: task.id,
+        receiverId: inviteReceiverId,
+      })
+
+      if (res.status === 'success' && res.data) {
+        setInvitations((prev) => [...prev, res.data!])
+        setShowInviteModal(false)
+        setInviteReceiverId(null)
+        setActionFeedback({
+          type: 'success',
+          message: `Invitation sent successfully to ${res.data.receiverUsername}.`,
+        })
+      } else {
+        setInviteError(res.message || 'Failed to send invitation')
+      }
+    } catch (e) {
+      setInviteError(e instanceof Error ? e.message : 'An error occurred')
+    } finally {
+      setIsInviting(false)
+    }
+  }
+
+  useEffect(() => {
     async function loadTask() {
       const parsedId = Number(id)
 
@@ -306,6 +360,7 @@ export function TaskDetailPage({
 
         if (currentUser) {
 
+          let hasActiveAssignment = false
           let foundAnyAssignment: TaskAssignmentResponse | null = null
           const assignmentsRes = await fetchAssignmentsByUser(currentUser.id, {
             page: 0,
@@ -317,6 +372,7 @@ export function TaskDetailPage({
               a => a.taskId === parsedId && a.status.toLowerCase() !== 'completed'
             )
             setUserAssignment(foundActive || null)
+            hasActiveAssignment = !!foundActive
 
             const foundAny = assignmentsRes.data.content.find(
               a => a.taskId === parsedId
@@ -325,16 +381,24 @@ export function TaskDetailPage({
             setAnyAssignment(foundAny || null)
           }
 
-          if (userIsOwner) {
+          if (userIsOwner || hasActiveAssignment) {
             const allAssignmentsRes = await fetchTaskAssignments(parsedId)
             if (allAssignmentsRes.status === 'success' && allAssignmentsRes.data) {
               const content = allAssignmentsRes.data.content || []
               setAssignments(content)
-              if (content.length > 0) {
+              if (userIsOwner && content.length > 0) {
                 setSelectedAssignment(content[0])
               }
             }
 
+            // Fetch task invitations
+            const invitesRes = await fetchInvitationsByTask(parsedId)
+            if (invitesRes.status === 'success' && invitesRes.data) {
+              setInvitations(invitesRes.data)
+            }
+          }
+
+          if (userIsOwner) {
             const subsRes = await fetchSubmissionsByTask(parsedId, { page: 0, size: 100 })
             if (subsRes.status === 'success' && subsRes.data) {
               setSubmissions(subsRes.data.content)
@@ -772,6 +836,105 @@ export function TaskDetailPage({
                   </div>
                 </CardBody>
               </Card>
+
+              {/* Team & Collaboration Card */}
+              {(isOwner || userAssignment) && (
+                <Card>
+                  <CardBody className="space-y-6 p-6 bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.06),transparent_35%)]">
+                    <div>
+                      <div className="flex items-center justify-between mb-4">
+                        <CardTitle className="text-2xl">Team & Collaboration</CardTitle>
+                        {userAssignment && !userAssignment.parentAssignmentId && userAssignment.status.toLowerCase() === 'active' && !isDeadlinePassed && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setShowInviteModal(true)}
+                            className="h-8 border-blue-200 text-blue-600 hover:bg-blue-50 font-semibold"
+                          >
+                            <UserPlus size={14} className="mr-1.5" />
+                            Invite Collaborator
+                          </Button>
+                        )}
+                      </div>
+
+                      <div className="space-y-4">
+                        {/* Assignees List */}
+                        <div>
+                          <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">Assigned Developers</h4>
+                          {assignments.length === 0 ? (
+                            <p className="text-sm text-slate-500 italic">No developers assigned yet.</p>
+                          ) : (
+                            <div className="flex flex-wrap gap-3">
+                              {assignments.map((ass) => {
+                                const isLead = !ass.parentAssignmentId
+                                return (
+                                  <div
+                                    key={ass.id}
+                                    className="flex items-center gap-2 bg-slate-50 border border-slate-200 rounded-xl px-3 py-1.5"
+                                  >
+                                    <span
+                                      onClick={() => navigate(`/user/${ass.userId}`)}
+                                      className="text-sm font-semibold text-slate-800 hover:underline cursor-pointer"
+                                    >
+                                      {ass.username}
+                                    </span>
+                                    <Badge
+                                      variant="outline"
+                                      className={isLead ? "bg-blue-50 text-blue-700 border-blue-200 text-[10px]" : "bg-slate-100 text-slate-600 border-slate-200 text-[10px]"}
+                                    >
+                                      {isLead ? 'Lead' : 'Collaborator'}
+                                    </Badge>
+                                  </div>
+                                )
+                              })}
+                            </div>
+                          )}
+                        </div>
+
+                        {/* Sent Invitations List (only for Lead or Project Owner) */}
+                        {(isOwner || (userAssignment && !userAssignment.parentAssignmentId)) && (
+                          <div className="pt-2 border-t border-slate-100">
+                            <h4 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">Sent Invitations</h4>
+                            {invitations.length === 0 ? (
+                              <p className="text-sm text-slate-500 italic">No invitations sent yet.</p>
+                            ) : (
+                              <div className="space-y-2">
+                                {invitations.map((invite) => {
+                                  const statusLower = invite.status.toLowerCase()
+                                  let statusClass = "bg-amber-50 text-amber-700 border-amber-200"
+                                  if (statusLower === 'accepted') statusClass = "bg-green-50 text-green-700 border-green-200"
+                                  if (statusLower === 'rejected') statusClass = "bg-red-50 text-red-700 border-red-200"
+
+                                  return (
+                                    <div
+                                      key={invite.id}
+                                      className="flex items-center justify-between bg-slate-50/50 border border-slate-200/60 rounded-xl px-4 py-2"
+                                    >
+                                      <div className="flex items-center gap-2">
+                                        <span
+                                          onClick={() => navigate(`/user/${invite.receiverId}`)}
+                                          className="text-sm font-medium text-slate-700 hover:underline cursor-pointer"
+                                        >
+                                          {invite.receiverUsername}
+                                        </span>
+                                        <span className="text-xs text-slate-400">invited by {invite.senderUsername}</span>
+                                      </div>
+                                      <Badge variant="outline" className={`${statusClass} text-[10px]`}>
+                                        {invite.status}
+                                      </Badge>
+                                    </div>
+                                  )
+                                })}
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </CardBody>
+                </Card>
+              )}
+
               {/* Submitted Proposals Card */}
               {(isOwner || anyAssignment) && (
                 <Card>
@@ -1587,6 +1750,73 @@ export function TaskDetailPage({
               </Button>
             </div>
           </form>
+        </Modal>
+      )}
+
+      {showInviteModal && (
+        <Modal
+          isOpen={showInviteModal}
+          onClose={() => {
+            setShowInviteModal(false)
+            setInviteReceiverId(null)
+            setInviteError(null)
+          }}
+          title="Invite Collaborator"
+        >
+          <div className="space-y-4 text-slate-900">
+            <div className="space-y-2">
+              <label className="block text-sm font-medium text-slate-700">Select Developer to Invite</label>
+              <select
+                value={inviteReceiverId || ''}
+                onChange={(e) => setInviteReceiverId(Number(e.target.value) || null)}
+                className="w-full bg-white border border-slate-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all font-medium text-slate-700"
+                disabled={isInviting}
+              >
+                <option value="">-- Choose a developer --</option>
+                {allUsers
+                  .filter((u) => {
+                    const assigneesUserIds = new Set(assignments.map((a) => a.userId))
+                    const invitedUserIds = new Set(invitations.map((i) => i.receiverId))
+                    return (
+                      u.id !== currentUser?.id &&
+                      u.id !== projectOwnerId &&
+                      !assigneesUserIds.has(u.id) &&
+                      !invitedUserIds.has(u.id)
+                    )
+                  })
+                  .map((u) => (
+                    <option key={u.id} value={u.id}>
+                      {u.username} {u.email ? `(${u.email})` : ''}
+                    </option>
+                  ))}
+              </select>
+            </div>
+            {inviteError && (
+              <div className="bg-red-50 border border-red-200 rounded-md p-3">
+                <p className="text-sm text-red-700">{inviteError}</p>
+              </div>
+            )}
+            <div className="flex gap-3 pt-2">
+              <Button
+                variant="primary"
+                onClick={handleSendInvitation}
+                disabled={isInviting || !inviteReceiverId}
+              >
+                {isInviting ? 'Sending Invitation...' : 'Send Invitation'}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowInviteModal(false)
+                  setInviteReceiverId(null)
+                  setInviteError(null)
+                }}
+                disabled={isInviting}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
         </Modal>
       )}
     </main>

--- a/src/pages/task-detail-page.tsx
+++ b/src/pages/task-detail-page.tsx
@@ -91,6 +91,7 @@ export function TaskDetailPage({
     status: 'OPEN',
     maxAttempts: 3,
     minReputation: 0,
+    collaborative: false,
     recommendedSkills: [],
   })
   const [editSkillsInput, setEditSkillsInput] = useState('')
@@ -175,6 +176,7 @@ export function TaskDetailPage({
       status: task.status,
       maxAttempts: task.maxAttempts,
       minReputation: task.minReputation,
+      collaborative: task.collaborative,
       recommendedSkills: task.recommendedSkills || [],
     })
     setEditSkillsInput((task.recommendedSkills || []).join(', '))
@@ -387,16 +389,16 @@ export function TaskDetailPage({
             setAnyAssignment(foundAny || null)
           }
 
-          if (userIsOwner || hasActiveAssignment) {
-            const allAssignmentsRes = await fetchTaskAssignments(parsedId)
-            if (allAssignmentsRes.status === 'success' && allAssignmentsRes.data) {
-              const content = allAssignmentsRes.data.content || []
-              setAssignments(content)
-              if (userIsOwner && content.length > 0) {
-                setSelectedAssignment(content[0])
-              }
+          const allAssignmentsRes = await fetchTaskAssignments(parsedId)
+          if (allAssignmentsRes.status === 'success' && allAssignmentsRes.data) {
+            const content = allAssignmentsRes.data.content || []
+            setAssignments(content)
+            if (userIsOwner && content.length > 0) {
+              setSelectedAssignment(content[0])
             }
+          }
 
+          if (userIsOwner || hasActiveAssignment) {
             // Fetch task invitations
             const invitesRes = await fetchInvitationsByTask(parsedId)
             if (invitesRes.status === 'success' && invitesRes.data) {
@@ -598,6 +600,19 @@ export function TaskDetailPage({
         text: 'Already Assigned',
         disabled: true,
         tooltip: `You were assigned on ${new Date(userAssignment.assignedAt).toLocaleDateString()}`,
+      }
+    }
+
+    if (task && !task.collaborative) {
+      const hasAnyActive = assignments.some(
+        (a) => a.status.toLowerCase() === 'active'
+      )
+      if (hasAnyActive) {
+        return {
+          text: 'Already Claimed',
+          disabled: true,
+          tooltip: 'This task has already been claimed by another developer.',
+        }
       }
     }
 
@@ -859,7 +874,7 @@ export function TaskDetailPage({
               </Card>
 
               {/* Team & Collaboration Card */}
-              {(isOwner || userAssignment) && (
+              {task.collaborative && (isOwner || userAssignment) && (
                 <Card>
                   <CardBody className="space-y-6 p-6 bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.06),transparent_35%)]">
                     <div>
@@ -1710,6 +1725,24 @@ export function TaskDetailPage({
                   }));
                 }}
               />
+            </div>
+
+            <div className="flex items-center gap-2 mt-6">
+              <input
+                id="edit-task-collaborative"
+                type="checkbox"
+                checked={editTaskForm.collaborative}
+                onChange={(event) => {
+                  setEditTaskForm((current) => ({
+                    ...current,
+                    collaborative: event.target.checked,
+                  }))
+                }}
+                className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+              />
+              <label htmlFor="edit-task-collaborative" className="text-sm font-medium text-slate-700 cursor-pointer">
+                Collaborative Task
+              </label>
             </div>
 
             <div className="md:col-span-2">

--- a/src/pages/task-detail-page.tsx
+++ b/src/pages/task-detail-page.tsx
@@ -103,6 +103,7 @@ export function TaskDetailPage({
   }>({})
   const [editFeedback, setEditFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
   const [isUpdatingTask, setIsUpdatingTask] = useState(false)
+  const [allowAnyReputation, setAllowAnyReputation] = useState(true)
   const [rejectionReason, setRejectionReason] = useState<'BUGS_OR_INCOMPLETE' | 'SPAM_OR_LOW_EFFORT'>('BUGS_OR_INCOMPLETE')
 
 
@@ -180,6 +181,7 @@ export function TaskDetailPage({
       recommendedSkills: task.recommendedSkills || [],
     })
     setEditSkillsInput((task.recommendedSkills || []).join(', '))
+    setAllowAnyReputation(!task.minReputation || task.minReputation <= -500)
     setEditErrors({})
     setEditFeedback(null)
     setShowEditModal(true)
@@ -198,6 +200,7 @@ export function TaskDetailPage({
 
     const updatedData = {
       ...editTaskForm,
+      minReputation: allowAnyReputation ? -500 : (editTaskForm.minReputation || 0),
       recommendedSkills: editSkillsInput
         .split(',')
         .map((skill) => skill.trim())
@@ -544,7 +547,7 @@ export function TaskDetailPage({
 
   const dashboard = readStoredProfileDashboard()
   const userReputation = dashboard?.stats?.reputationScore ?? 0
-  const isReputationTooLow = currentUser && task && userReputation < task.minReputation
+  const isReputationTooLow = currentUser && task && task.minReputation > -500 && userReputation < task.minReputation
   const isDeadlinePassed = task && task.deadline && new Date(task.deadline).getTime() < Date.now()
 
   const eligibleUsers = allUsers.filter((u) => {
@@ -867,7 +870,9 @@ export function TaskDetailPage({
                       </div>
                       <div className="space-y-2">
                         <p className="text-sm text-slate-500">Min Reputation Required</p>
-                        <p className="text-base text-slate-900">{task.minReputation}</p>
+                        <p className="text-base text-slate-900">
+                          {task.minReputation <= -500 ? 'None' : task.minReputation}
+                        </p>
                       </div>
                       <div className="space-y-2">
                         <p className="text-sm text-slate-500">Deadline</p>
@@ -1732,21 +1737,52 @@ export function TaskDetailPage({
               />
             </div>
 
-            <div>
-              <label className="block text-sm font-medium mb-1 text-slate-700">Minimum Reputation Required</label>
-              <Input
-                type="number"
-                placeholder="0"
-                value={editTaskForm.minReputation === undefined ? "" : editTaskForm.minReputation}
-                onChange={(event) => {
-                  const value = event.target.value;
-                  setEditTaskForm((current) => ({
-                    ...current,
-                    minReputation: value === "" ? 0 : Number(value),
-                  }));
-                }}
-              />
+            <div className="flex flex-col justify-center gap-2">
+              <div className="flex items-center gap-2 mt-6">
+                <input
+                  id="edit-task-any-rep"
+                  type="checkbox"
+                  checked={allowAnyReputation}
+                  onChange={(event) => {
+                    const checked = event.target.checked
+                    setAllowAnyReputation(checked)
+                    if (checked) {
+                      setEditTaskForm((current) => ({
+                        ...current,
+                        minReputation: -500,
+                      }))
+                    } else {
+                      setEditTaskForm((current) => ({
+                        ...current,
+                        minReputation: 0,
+                      }))
+                    }
+                  }}
+                  className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                />
+                <label htmlFor="edit-task-any-rep" className="text-sm font-medium text-slate-700 cursor-pointer">
+                  Any reputation score
+                </label>
+              </div>
             </div>
+
+            {!allowAnyReputation && (
+              <div>
+                <label className="block text-sm font-medium mb-1 text-slate-700">Minimum Reputation Required</label>
+                <Input
+                  type="number"
+                  placeholder="0"
+                  value={editTaskForm.minReputation === undefined ? "" : editTaskForm.minReputation}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    setEditTaskForm((current) => ({
+                      ...current,
+                      minReputation: value === "" ? 0 : Number(value),
+                    }));
+                  }}
+                />
+              </div>
+            )}
 
             <div className="flex items-center gap-2 mt-6">
               <input

--- a/src/pages/task-detail-page.tsx
+++ b/src/pages/task-detail-page.tsx
@@ -14,7 +14,7 @@ import { fetchTaskById, updateTask } from '../lib/task-storage'
 import { createSubmission, fetchSubmissionsByTask, fetchSubmissionsByAssignment, updateSubmission } from '../lib/submission-storage'
 import { fetchAssignmentsByUser, createAssignment } from '../lib/assignment-storage'
 import { createInvitation, fetchInvitationsByTask } from '../lib/task-invitation-storage'
-import { fetchAllUsers } from '../lib/user-storage'
+import { fetchAllUserDetails } from '../lib/user-storage'
 import { LOOKUP_PAGE_SIZE } from '../lib/pagination'
 import { fetchTaskAssignments } from '../lib/chat-storage'
 import { TaskChatPanel } from '../components/app/task-chat-panel'
@@ -76,6 +76,7 @@ export function TaskDetailPage({
   const [isInviting, setIsInviting] = useState(false)
   const [inviteError, setInviteError] = useState<string | null>(null)
   const [allUsers, setAllUsers] = useState<User[]>([])
+  const [inviteSearchQuery, setInviteSearchQuery] = useState('')
 
   // State for task editing
   const [showEditModal, setShowEditModal] = useState(false)
@@ -283,9 +284,14 @@ export function TaskDetailPage({
     if (showInviteModal) {
       async function loadUsers() {
         try {
-          const res = await fetchAllUsers()
+          const res = await fetchAllUserDetails()
           if (res.status === 'success' && res.data) {
-            setAllUsers(res.data)
+            const mappedUsers: User[] = res.data.map(u => ({
+              id: u.id,
+              username: u.username,
+              email: u.email
+            }))
+            setAllUsers(mappedUsers)
           }
         } catch (e) {
           console.error("Failed to load users for invitation", e)
@@ -538,6 +544,21 @@ export function TaskDetailPage({
   const userReputation = dashboard?.stats?.reputationScore ?? 0
   const isReputationTooLow = currentUser && task && userReputation < task.minReputation
   const isDeadlinePassed = task && task.deadline && new Date(task.deadline).getTime() < Date.now()
+
+  const eligibleUsers = allUsers.filter((u) => {
+    const assigneesUserIds = new Set(assignments.map((a) => a.userId))
+    const invitedUserIds = new Set(invitations.map((i) => i.receiverId))
+    return (
+      u.id !== currentUser?.id &&
+      u.id !== projectOwnerId &&
+      !assigneesUserIds.has(u.id) &&
+      !invitedUserIds.has(u.id)
+    )
+  })
+
+  const filteredEligibleUsers = eligibleUsers.filter((u) =>
+    u.username.toLowerCase().includes(inviteSearchQuery.toLowerCase())
+  )
 
   const getAssignmentButtonContent = () => {
     if (isDeadlinePassed) {
@@ -1760,37 +1781,79 @@ export function TaskDetailPage({
             setShowInviteModal(false)
             setInviteReceiverId(null)
             setInviteError(null)
+            setInviteSearchQuery('')
           }}
           title="Invite Collaborator"
         >
           <div className="space-y-4 text-slate-900">
             <div className="space-y-2">
-              <label className="block text-sm font-medium text-slate-700">Select Developer to Invite</label>
-              <select
-                value={inviteReceiverId || ''}
-                onChange={(e) => setInviteReceiverId(Number(e.target.value) || null)}
-                className="w-full bg-white border border-slate-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all font-medium text-slate-700"
+              <label className="block text-sm font-medium text-slate-700">Search Developer to Invite</label>
+              <Input
+                type="text"
+                placeholder="Type username to search..."
+                value={inviteSearchQuery}
+                onChange={(e) => setInviteSearchQuery(e.target.value)}
                 disabled={isInviting}
-              >
-                <option value="">-- Choose a developer --</option>
-                {allUsers
-                  .filter((u) => {
-                    const assigneesUserIds = new Set(assignments.map((a) => a.userId))
-                    const invitedUserIds = new Set(invitations.map((i) => i.receiverId))
-                    return (
-                      u.id !== currentUser?.id &&
-                      u.id !== projectOwnerId &&
-                      !assigneesUserIds.has(u.id) &&
-                      !invitedUserIds.has(u.id)
-                    )
-                  })
-                  .map((u) => (
-                    <option key={u.id} value={u.id}>
-                      {u.username} {u.email ? `(${u.email})` : ''}
-                    </option>
-                  ))}
-              </select>
+              />
             </div>
+
+            {/* Results List */}
+            <div className="border border-slate-200 rounded-lg max-h-[220px] overflow-y-auto divide-y divide-slate-100 bg-white shadow-inner">
+              {filteredEligibleUsers.length === 0 ? (
+                <p className="text-sm text-slate-500 p-4 text-center italic">
+                  {inviteSearchQuery ? `No developers found matching "${inviteSearchQuery}"` : "No developers available to invite"}
+                </p>
+              ) : (
+                filteredEligibleUsers.map((u) => {
+                  const isSelected = inviteReceiverId === u.id
+                  return (
+                    <div
+                      key={u.id}
+                      onClick={() => setInviteReceiverId(u.id)}
+                      className={`flex items-center justify-between px-4 py-3 cursor-pointer transition-colors ${
+                        isSelected ? 'bg-blue-50/70 text-blue-900 font-semibold' : 'hover:bg-slate-50 text-slate-700'
+                      }`}
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-100 font-bold text-slate-600 text-sm uppercase">
+                          {u.username.charAt(0)}
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium">{u.username}</p>
+                          {u.email && <p className="text-xs text-slate-400 font-normal">{u.email}</p>}
+                        </div>
+                      </div>
+                      {isSelected && (
+                        <span className="text-blue-600">
+                          <Check size={16} />
+                        </span>
+                      )}
+                    </div>
+                  )
+                })
+              )}
+            </div>
+
+            {/* Selected developer indicator */}
+            {inviteReceiverId && (
+              <div className="flex items-center justify-between rounded-xl bg-blue-50/50 border border-blue-200/60 p-3 animate-in fade-in zoom-in-95 duration-200">
+                <div className="flex items-center gap-2.5">
+                  <div className="h-2 w-2 rounded-full bg-blue-500 animate-pulse"></div>
+                  <p className="text-sm font-medium text-blue-900">
+                    Selected: <span className="font-bold">{allUsers.find(u => u.id === inviteReceiverId)?.username}</span>
+                  </p>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setInviteReceiverId(null)}
+                  className="h-7 w-7 p-0 rounded-full hover:bg-blue-100/50 text-blue-600"
+                >
+                  <X size={14} />
+                </Button>
+              </div>
+            )}
+
             {inviteError && (
               <div className="bg-red-50 border border-red-200 rounded-md p-3">
                 <p className="text-sm text-red-700">{inviteError}</p>
@@ -1810,6 +1873,7 @@ export function TaskDetailPage({
                   setShowInviteModal(false)
                   setInviteReceiverId(null)
                   setInviteError(null)
+                  setInviteSearchQuery('')
                 }}
                 disabled={isInviting}
               >

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -133,6 +133,7 @@ export type TaskRequest = {
   status: string,
   maxAttempts: number,
   minReputation?: number,
+  collaborative: boolean,
   recommendedSkills: string[]
 }
 
@@ -150,6 +151,7 @@ export type TaskResponse = {
   fundingStatus?: string | null,
   maxAttempts: number,
   minReputation: number,
+  collaborative: boolean,
   createdAt: Date,
   updatedAt: Date,
   recommendedSkills: string[]

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -170,13 +170,33 @@ export type TaskAssignmentResponse = {
   username: string,
   assignedAt: Date,
   status: string,
-  attemptsUsed: number
+  attemptsUsed: number,
+  parentAssignmentId?: number | null
 }
 
 export type TaskAssignmentUpdateRequest = {
   id: number
   status: string
   attemptsUsed: number
+}
+
+export type TaskInvitationRequest = {
+  taskId: number
+  receiverId: number
+}
+
+export type TaskInvitationResponse = {
+  id: number
+  taskId: number
+  taskTitle: string
+  projectId: number
+  projectName: string
+  senderId: number
+  senderUsername: string
+  receiverId: number
+  receiverUsername: string
+  status: string
+  createdAt: string
 }
 
 export type TaskSubmissionRequest = {


### PR DESCRIPTION
Here is a complete recap of all the changes we have made, organized by feature:

  ### 1. Collaborative Tasks Feature

  We enabled tasks to support multiple concurrent developers/teams working on them if specified by the project owner.

  • Backend Changes:
      • Model (Task.java): Added the  collaborative  column, defaulting to  false .
      • DTOs: Modified  TaskRequest ,  TaskResponse , and  TaskUpdateRequest  to include and map the  collaborative  state.
      • Validation (TaskAssignmentService.java): Replaced the global single-active-assignment restriction with conditional
  logic:
          • Standard task: Restricts more than one active assignment globally.
          • Collaborative task: Permits multiple active assignments, only preventing the same user from claiming it twice.

  • Frontend Changes:
      • Type Definitions (app.ts): Updated  TaskRequest  and  TaskResponse  to include the  collaborative: boolean
      property.
      • Creation Forms: Added a "Collaborative Task" checkbox inside:
          • create-task-modal.tsx (Dashboard page creation).                                                                 
          • project-detail-page.tsx (Project details task creation).                                                         
          • tasks.tsx (Profile My Tasks tab creation).
          • task-detail-page.tsx (Edit task modal).
      • Task Details Page (task-detail-page.tsx):
          • Unconditional Fetch: Fetch assignments on page load for all logged-in users.
          • Conditional button disabling: If the task is standard and claimed, others see "Already Claimed" (disabled). If
          collaborative, others can assign themselves ("Assign to Me").


  ──────
  ### 2. Team Isolation on Collaborative Tasks

  We ensured that when multiple teams assign themselves to a collaborative task, their collaborators and invitations are
  kept private.

  • Frontend Changes (task-detail-page.tsx):
      • Filter Calculations: Calculated the specific  teamLeadId  for the logged-in developer (using their own assignment)
      or the owner (using the currently selected conversation).
      • Filtered Lists: Filtered  assignments  into  teamAssignments  and  invitations  into  teamInvitations .
      • Filtered UI: Updated the Team & Collaboration card to render only those filtered lists. Developer teams can no
      longer see other teams' members or invitations, while the owner sees the team members of whichever conversation they
      have selected.

  ──────
  ### 3. Reputation Range Limits & "Any Reputation" Toggle

  We bounded developer reputation scores and simplified the UX for selecting reputation requirements.

  • Backend Changes:
      • User Model (User.java):
          • Implemented a custom setter  setReputation_score  that clamps the reputation score between  -500  and  1500 .
          • Implemented clamping inside  @PrePersist  and  @PreUpdate  hooks to enforce data integrity before saving to
          the database.
      • Mapping (TaskResponse.java): Added a null-safe mapping mapping database  NULL  collaborative column values to  false
  .
  • Frontend Changes:
      • Creation/Edit Forms: Added an "Any reputation score" checkbox toggle, defaulting to  true  (checked).
          • When checked: The minimum reputation input field is hidden, and the sentinel value  -500  (our new absolute
          minimum) is submitted. Since developer scores cannot drop below  -500 , any developer can claim it.
          • When unchecked: The minimum reputation input field appears, allowing projects to specify a min reputation gate.
      • Task Details Page (task-detail-page.tsx):
          • Bypassed the "Reputation Too Low" validation checks if  task.minReputation <= -500 .
          • Rendered "None" under "Min Reputation Required" in the details card instead of displaying  -500 .
          • Pre-populated the checkbox state dynamically when editing based on whether the existing task requirement was
          ≤ -500 .
